### PR TITLE
feat(pseudovoigt): compute the factor based on mu parameter

### DIFF
--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -8,6 +8,8 @@ import { Parameter, Shape1DClass } from '../Shape1DClass';
 import { gaussianFct, getGaussianFactor } from '../gaussian/Gaussian';
 import { lorentzianFct, getLorentzianFactor } from '../lorentzian/Lorentzian';
 
+import { pseudoVoigtFindFactor } from './computeFactor';
+
 export interface PseudoVoigtClassOptions {
   /**
    * Full width at half maximum.
@@ -86,7 +88,7 @@ export class PseudoVoigt implements Shape1DClass {
   }
 
   public getFactor(area?: number) {
-    return getPseudoVoigtFactor(area);
+    return getPseudoVoigtFactor(area, this.mu);
   }
 
   public getData(options: GetData1DOptions = {}) {
@@ -136,7 +138,9 @@ export const getPseudoVoigtArea = (options: GetPseudoVoigtAreaOptions) => {
 };
 
 export const getPseudoVoigtFactor = (area = 0.9999, mu = 0.5) => {
-  return mu < 1 ? getLorentzianFactor(area) : getGaussianFactor(area);
+  if (mu === 0) return getLorentzianFactor(area);
+  if (mu === 1) return getGaussianFactor(area);
+  return pseudoVoigtFindFactor(area, mu);
 };
 
 export const getPseudoVoigtData = (

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -5,8 +5,8 @@ import {
 } from '../../../util/constants';
 import { GetData1DOptions } from '../GetData1DOptions';
 import { Parameter, Shape1DClass } from '../Shape1DClass';
-import { gaussianFct, getGaussianFactor } from '../gaussian/Gaussian';
-import { lorentzianFct, getLorentzianFactor } from '../lorentzian/Lorentzian';
+import { gaussianFct } from '../gaussian/Gaussian';
+import { lorentzianFct } from '../lorentzian/Lorentzian';
 
 import { pseudoVoigtFindFactor } from './computeFactor';
 
@@ -138,8 +138,6 @@ export const getPseudoVoigtArea = (options: GetPseudoVoigtAreaOptions) => {
 };
 
 export const getPseudoVoigtFactor = (area = 0.9999, mu = 0.5) => {
-  if (mu === 0) return getLorentzianFactor(area);
-  if (mu === 1) return getGaussianFactor(area);
   return pseudoVoigtFindFactor(area, mu);
 };
 

--- a/src/shapes/1d/pseudoVoigt/__tests__/computeFactor.test.ts
+++ b/src/shapes/1d/pseudoVoigt/__tests__/computeFactor.test.ts
@@ -1,0 +1,30 @@
+import { getPseudoVoigtFactor } from '../PseudoVoigt';
+import { pseudoVoigtFindFactor } from '../computeFactor';
+
+describe('pseudoVoigt factor computation', () => {
+  it('returns edge values for pTarget boundaries', () => {
+    expect(pseudoVoigtFindFactor(0, 0.5)).toBe(0);
+    expect(pseudoVoigtFindFactor(1, 0.5)).toBe(Infinity);
+  });
+
+  it('reduces to tan for mu === 1', () => {
+    const p = 0.5;
+    const expected = Math.tan((Math.PI / 2) * p);
+    expect(pseudoVoigtFindFactor(p, 1)).toBeCloseTo(expected, 12);
+  });
+
+  it('finds a finite factor for typical inputs', () => {
+    const f = pseudoVoigtFindFactor(0.999, 0.5);
+    expect(f).toBeGreaterThan(0);
+    expect(Number.isFinite(f)).toBe(true);
+  });
+
+  it('getPseudoVoigtFactor returns finite values for extreme mu', () => {
+    const f0 = getPseudoVoigtFactor(0.9, 0);
+    const f1 = getPseudoVoigtFactor(0.9, 1);
+    expect(Number.isFinite(f0)).toBe(true);
+    expect(Number.isFinite(f1)).toBe(true);
+    expect(f0).toBeGreaterThanOrEqual(0);
+    expect(f1).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/shapes/1d/pseudoVoigt/__tests__/computeFactor.test.ts
+++ b/src/shapes/1d/pseudoVoigt/__tests__/computeFactor.test.ts
@@ -1,27 +1,60 @@
+import { getGaussianFactor } from '../../gaussian/Gaussian';
+import { getLorentzianFactor } from '../../lorentzian/Lorentzian';
 import { getPseudoVoigtFactor } from '../PseudoVoigt';
 import { pseudoVoigtFindFactor } from '../computeFactor';
 
-describe('pseudoVoigt factor computation', () => {
-  it('returns edge values for pTarget boundaries', () => {
-    expect(pseudoVoigtFindFactor(0, 0.5)).toBe(0);
-    expect(pseudoVoigtFindFactor(1, 0.5)).toBe(Infinity);
+describe('pseudoVoigtFindFactor', () => {
+  describe('input validation', () => {
+    it.each([
+      [-0.1, 0.5],
+      [0, 0.5],
+      [1, 0.5],
+      [1.1, 0.5],
+    ])('throws for invalid pTarget=%p', (pTarget, mu) => {
+      expect(() => pseudoVoigtFindFactor(pTarget, mu)).toThrow(RangeError);
+    });
   });
 
-  it('reduces to tan for mu === 1', () => {
-    const p = 0.5;
-    const expected = Math.tan((Math.PI / 2) * p);
-    expect(pseudoVoigtFindFactor(p, 1)).toBeCloseTo(expected, 12);
+  describe('special mu behavior', () => {
+    it('falls back to gaussian factor when mu === 1', () => {
+      const pTarget = 0.5;
+      expect(pseudoVoigtFindFactor(pTarget, 1)).toBeCloseTo(
+        getGaussianFactor(pTarget),
+        12,
+      );
+    });
+
+    it('falls back to lorentzian factor when mu === 0', () => {
+      const pTarget = 0.5;
+      expect(pseudoVoigtFindFactor(pTarget, 0)).toBeCloseTo(
+        getLorentzianFactor(pTarget),
+        12,
+      );
+    });
   });
 
-  it('finds a finite factor for typical inputs', () => {
-    const f = pseudoVoigtFindFactor(0.999, 0.5);
-    expect(f).toBeGreaterThan(0);
-    expect(Number.isFinite(f)).toBe(true);
+  describe('typical factor values', () => {
+    it.each([
+      [0.001, 0.25],
+      [0.25, 0.5],
+      [0.75, 0.75],
+      [0.999, 0.5],
+    ])(
+      'returns a finite positive factor for pTarget=%p mu=%p',
+      (pTarget, mu) => {
+        const factor = pseudoVoigtFindFactor(pTarget, mu);
+        expect(factor).toBeGreaterThan(0);
+        expect(Number.isFinite(factor)).toBe(true);
+      },
+    );
   });
+});
 
-  it('getPseudoVoigtFactor returns finite values for extreme mu', () => {
+describe('getPseudoVoigtFactor', () => {
+  it('returns finite values for extreme mu values', () => {
     const f0 = getPseudoVoigtFactor(0.9, 0);
     const f1 = getPseudoVoigtFactor(0.9, 1);
+
     expect(Number.isFinite(f0)).toBe(true);
     expect(Number.isFinite(f1)).toBe(true);
     expect(f0).toBeGreaterThanOrEqual(0);

--- a/src/shapes/1d/pseudoVoigt/computeFactor.ts
+++ b/src/shapes/1d/pseudoVoigt/computeFactor.ts
@@ -1,0 +1,65 @@
+/**
+ * Find the k factor for a pseudo-Voigt distribution such that the
+ * cumulative probability pPseudoVoigt(k, mu) equals `pTarget`.
+ *
+ * Uses a simple bisection search (with exponential bracketing) to
+ * invert the pseudo-Voigt cumulative function. Special cases:
+ * - pTarget <= 0 -> returns 0
+ * - pTarget >= 1 -> returns Infinity
+ * - mu === 1 -> reduces to the gaussian case and returns tan((pi/2)*pTarget)
+ *
+ * @param pTarget - Target cumulative probability in (0,1)
+ * @param mu - Gaussian fraction in [0,1]
+ * @param tol - Convergence tolerance
+ * @param maxIter - Maximum number of bisection iterations
+ * @returns the factor k such that pPseudoVoigt(k, mu) ~= pTarget
+ */
+export function pseudoVoigtFindFactor(
+  pTarget: number,
+  mu: number,
+  tol = 1e-9,
+  maxIter = 200,
+) {
+  if (pTarget <= 0) return 0;
+  if (pTarget >= 1) return Infinity;
+  if (mu === 1) return Math.tan((Math.PI / 2) * pTarget);
+  // bisection
+  let lo = 0;
+  let hi = 10;
+  let it = 0;
+  while (pPseudoVoigt(hi, mu) < pTarget && it++ < 200) hi *= 2;
+  for (let i = 0; i < maxIter; i++) {
+    const mid = 0.5 * (lo + hi);
+    const val = pPseudoVoigt(mid, mu);
+    if (Math.abs(val - pTarget) < tol) return mid;
+    if (val < pTarget) lo = mid;
+    else hi = mid;
+  }
+  return 0.5 * (lo + hi);
+}
+
+function erf(x: number) {
+  const sign = x < 0 ? -1 : 1;
+  x = Math.abs(x);
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+  const t = 1 / (1 + p * x);
+  const y =
+    1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+  return sign * y;
+}
+
+const sqrtLn2 = Math.sqrt(Math.log(2));
+function pGaussian(k: number) {
+  return erf(k * sqrtLn2);
+}
+function pLorentz(k: number) {
+  return (2 / Math.PI) * Math.atan(k);
+}
+function pPseudoVoigt(k: number, mu: number) {
+  return (1 - mu) * pLorentz(k) + mu * pGaussian(k);
+}

--- a/src/shapes/1d/pseudoVoigt/computeFactor.ts
+++ b/src/shapes/1d/pseudoVoigt/computeFactor.ts
@@ -40,8 +40,11 @@ export function pseudoVoigtFindFactor(
     const mid = 0.5 * (lo + hi);
     const val = pPseudoVoigt(mid, mu);
     if (Math.abs(val - pTarget) < tol) return mid;
-    if (val < pTarget) lo = mid;
-    else hi = mid;
+    if (val < pTarget) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
   }
   return 0.5 * (lo + hi);
 }

--- a/src/shapes/1d/pseudoVoigt/computeFactor.ts
+++ b/src/shapes/1d/pseudoVoigt/computeFactor.ts
@@ -1,13 +1,14 @@
+import { getGaussianFactor } from '../gaussian/Gaussian';
+import { getLorentzianFactor } from '../lorentzian/Lorentzian';
+
 /**
  * Find the k factor for a pseudo-Voigt distribution such that the
  * cumulative probability pPseudoVoigt(k, mu) equals `pTarget`.
  *
  * Uses a simple bisection search (with exponential bracketing) to
  * invert the pseudo-Voigt cumulative function. Special cases:
- * - pTarget <= 0 -> returns 0
- * - pTarget >= 1 -> returns Infinity
- * - mu === 1 -> reduces to the gaussian case and returns tan((pi/2)*pTarget)
- *
+ * - mu === 1 -> reduces to the gaussian case
+ * - mu === 0 -> reduces to the lorentzian case
  * @param pTarget - Target cumulative probability in (0,1)
  * @param mu - Gaussian fraction in [0,1]
  * @param tol - Convergence tolerance
@@ -20,9 +21,16 @@ export function pseudoVoigtFindFactor(
   tol = 1e-9,
   maxIter = 200,
 ) {
-  if (pTarget <= 0) return 0;
-  if (pTarget >= 1) return Infinity;
-  if (mu === 1) return Math.tan((Math.PI / 2) * pTarget);
+  if (pTarget <= 0 || pTarget >= 1) {
+    throw new RangeError('pTarget must be in (0,1)');
+  }
+
+  if (mu === 1) {
+    return getGaussianFactor(pTarget);
+  } else if (mu === 0) {
+    return getLorentzianFactor(pTarget);
+  }
+
   // bisection
   let lo = 0;
   let hi = 10;


### PR DESCRIPTION
the Idea is to reduce as much as possible the factor of FWHM to cover a desired area for pseudovoigt shape. 

Currently the factor is the same for lorentzian shape if `mu` is different than 1 (gaussian), it means a factor of aprox 32 to cover a desired area of 98 %. It is not really needed for values of mu greater than zero. 

The proposal is to computed the factor based numerically and the results looks acceptable: 
<img width="567" height="217" alt="image" src="https://github.com/user-attachments/assets/44b4283e-e877-4de7-8faf-6c25fb468524" />
