### PR TITLE
feat: add analytical derivative to all 1D shapes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ export type {
   Shape1D,
 } from './shapes/1d/Shape1D.ts';
 export type { GaussianShape2D, Shape2D } from './shapes/2d/Shape2D.ts';
-export type { Shape1DClass } from './shapes/1d/Shape1DClass.ts';
+export type {
+  Shape1DClass,
+  Shape1DDerivative,
+} from './shapes/1d/Shape1DClass.ts';
 export type { Shape2DClass } from './shapes/2d/Shape2DClass.ts';
 export type { Shape1DInstance } from './shapes/1d/Shape1DInstance.ts';
 export type { Shape2DInstance } from './shapes/2d/Shape2DInstance.ts';

--- a/src/shapes/1d/Shape1DClass.ts
+++ b/src/shapes/1d/Shape1DClass.ts
@@ -4,6 +4,18 @@ import type { GetData1DOptions } from './GetData1DOptions.ts';
 
 export type Parameter = 'fwhm' | 'mu' | 'gamma' | 'fwhmG' | 'fwhmL';
 
+export interface Shape1DDerivative {
+  /** Value of `fct(x)`. */
+  fct: number;
+  /** Partial derivative of `fct` with respect to `x`, evaluated at `x`. */
+  dx: number;
+  /**
+   * Partial derivatives of `fct` with respect to each shape parameter,
+   * in the same order as `getParameters()`.
+   */
+  parameters: number[];
+}
+
 export interface Shape1DClass {
   fwhm: number;
   /**
@@ -47,4 +59,12 @@ export interface Shape1DClass {
    * Returns an array of the different parameters characterizing the shape
    */
   getParameters(): Parameter[];
+  /**
+   * Analytical partial derivatives of `fct` at `x`, with respect to `x` and to
+   * each shape parameter (in the same order as `getParameters()`). Every shape
+   * provides a closed-form Jacobian, so consumers (e.g. curve fitting) can use
+   * it directly instead of numerical differentiation.
+   * @param x - position at which to evaluate the derivatives.
+   */
+  derivative(x: number): Shape1DDerivative;
 }

--- a/src/shapes/1d/gaussian/Gaussian.ts
+++ b/src/shapes/1d/gaussian/Gaussian.ts
@@ -5,7 +5,11 @@ import {
 } from '../../../util/constants.ts';
 import erfinv from '../../../util/erfinv.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { Parameter, Shape1DClass } from '../Shape1DClass.ts';
+import type {
+  Parameter,
+  Shape1DClass,
+  Shape1DDerivative,
+} from '../Shape1DClass.ts';
 
 interface CalculateGaussianHeightOptions {
   /**
@@ -94,6 +98,11 @@ export class Gaussian implements Shape1DClass {
   public getParameters(): Parameter[] {
     return ['fwhm'];
   }
+
+  public derivative(x: number): Shape1DDerivative {
+    const { fct, dx, dFwhm } = gaussianDerivative(x, this.fwhm);
+    return { fct, dx, parameters: [dFwhm] };
+  }
 }
 
 /**
@@ -120,6 +129,20 @@ export function calculateGaussianHeight(
  */
 export function gaussianFct(x: number, fwhm: number) {
   return Math.exp(GAUSSIAN_EXP_FACTOR * (x / fwhm) ** 2);
+}
+
+/**
+ * Analytical value and partial derivatives of the gaussian function centered at x=0.
+ * @param x - position at which to evaluate.
+ * @param fwhm - full width at half maximum.
+ * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`) and `fwhm` (`dFwhm`).
+ */
+export function gaussianDerivative(x: number, fwhm: number) {
+  const fct = gaussianFct(x, fwhm);
+  const dx = ((2 * GAUSSIAN_EXP_FACTOR * x) / (fwhm * fwhm)) * fct;
+  const dFwhm =
+    ((-2 * GAUSSIAN_EXP_FACTOR * x * x) / (fwhm * fwhm * fwhm)) * fct;
+  return { fct, dx, dFwhm };
 }
 
 /**

--- a/src/shapes/1d/gaussian/__tests__/Gaussian.derivative.test.ts
+++ b/src/shapes/1d/gaussian/__tests__/Gaussian.derivative.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest';
+
+import { Gaussian, gaussianDerivative, gaussianFct } from '../Gaussian.ts';
+
+const fwhm = 0.3;
+const h = 1e-6;
+
+test('gaussianDerivative matches numerical derivatives', () => {
+  for (const x of [-0.4, -0.1, 0, 0.05, 0.25]) {
+    const { fct, dx, dFwhm } = gaussianDerivative(x, fwhm);
+
+    expect(fct).toBeCloseTo(gaussianFct(x, fwhm), 12);
+
+    const numericalDx =
+      (gaussianFct(x + h, fwhm) - gaussianFct(x - h, fwhm)) / (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 6);
+
+    const numericalDFwhm =
+      (gaussianFct(x, fwhm + h) - gaussianFct(x, fwhm - h)) / (2 * h);
+
+    expect(dFwhm).toBeCloseTo(numericalDFwhm, 6);
+  }
+});
+
+test('Gaussian.derivative returns parameters in getParameters() order', () => {
+  const gaussian = new Gaussian({ fwhm });
+  const { fct, dx, parameters } = gaussian.derivative(0.05);
+  const expected = gaussianDerivative(0.05, fwhm);
+
+  expect(gaussian.getParameters()).toStrictEqual(['fwhm']);
+  expect(fct).toBeCloseTo(expected.fct, 12);
+  expect(dx).toBeCloseTo(expected.dx, 12);
+  expect(parameters).toHaveLength(1);
+  expect(parameters[0]).toBeCloseTo(expected.dFwhm, 12);
+});

--- a/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
+++ b/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
@@ -142,11 +142,11 @@ export const generalizedLorentzianFct = (
  * @param gamma - kurtosis parameter of the shape.
  * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`), `fwhm` (`dFwhm`) and `gamma` (`dGamma`).
  */
-export const generalizedLorentzianDerivative = (
+export function generalizedLorentzianDerivative(
   x: number,
   fwhm: number,
   gamma: number,
-) => {
+) {
   const u = ((2 * x) / fwhm) ** 2;
   const lorentzian = 1 / (1 + u); // A
   const rational = (1 + u / 2) / (1 + u + u * u); // B
@@ -166,7 +166,7 @@ export const generalizedLorentzianDerivative = (
   const dFwhm = dFctDu * duDfwhm;
   const dGamma = rational - lorentzian; // B - A
   return { fct, dx, dFwhm, dGamma };
-};
+}
 
 export const generalizedLorentzianWidthToFWHM = (width: number) => {
   return width * ROOT_THREE;

--- a/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
+++ b/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
@@ -1,6 +1,10 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { Parameter, Shape1DClass } from '../Shape1DClass.ts';
+import type {
+  Parameter,
+  Shape1DClass,
+  Shape1DDerivative,
+} from '../Shape1DClass.ts';
 
 export interface GeneralizedLorentzianClassOptions {
   /**
@@ -91,6 +95,15 @@ export class GeneralizedLorentzian implements Shape1DClass {
   public getParameters(): Parameter[] {
     return ['fwhm', 'gamma'];
   }
+
+  public derivative(x: number): Shape1DDerivative {
+    const { fct, dx, dFwhm, dGamma } = generalizedLorentzianDerivative(
+      x,
+      this.fwhm,
+      this.gamma,
+    );
+    return { fct, dx, parameters: [dFwhm, dGamma] };
+  }
 }
 
 export const calculateGeneralizedLorentzianHeight = ({
@@ -120,6 +133,39 @@ export const generalizedLorentzianFct = (
 ) => {
   const u = ((2 * x) / fwhm) ** 2;
   return (1 - gamma) / (1 + u) + (gamma * (1 + u / 2)) / (1 + u + u ** 2);
+};
+
+/**
+ * Analytical value and partial derivatives of the generalized lorentzian function centered at x=0.
+ * @param x - position at which to evaluate.
+ * @param fwhm - full width at half maximum.
+ * @param gamma - kurtosis parameter of the shape.
+ * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`), `fwhm` (`dFwhm`) and `gamma` (`dGamma`).
+ */
+export const generalizedLorentzianDerivative = (
+  x: number,
+  fwhm: number,
+  gamma: number,
+) => {
+  const u = ((2 * x) / fwhm) ** 2;
+  const lorentzian = 1 / (1 + u); // A
+  const rational = (1 + u / 2) / (1 + u + u * u); // B
+  const fct = (1 - gamma) * lorentzian + gamma * rational;
+
+  // dA/du and dB/du
+  const dLorentzianDu = -1 / ((1 + u) * (1 + u));
+  const denominator = 1 + u + u * u;
+  const dRationalDu =
+    -(0.5 + 2 * u + 0.5 * u * u) / (denominator * denominator);
+  const dFctDu = (1 - gamma) * dLorentzianDu + gamma * dRationalDu;
+
+  const duDx = (8 * x) / (fwhm * fwhm);
+  const duDfwhm = (-8 * x * x) / (fwhm * fwhm * fwhm);
+
+  const dx = dFctDu * duDx;
+  const dFwhm = dFctDu * duDfwhm;
+  const dGamma = rational - lorentzian; // B - A
+  return { fct, dx, dFwhm, dGamma };
 };
 
 export const generalizedLorentzianWidthToFWHM = (width: number) => {

--- a/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
+++ b/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
@@ -38,7 +38,7 @@ interface GetGeneralizedLorentzianAreaOptions {
  * This shape is a linear combination of rational function (n|n+2), for n = 0 (lorentzian function) and n = 2
  * the parameter that combines those two functions is `gamma` and it is called the kurtosis parameter, it is an
  * implementation of generalized lorentzian shape published by Stanislav Sykora in the SMASH 2010. DOI:10.3247/SL3nmr10.006
- * {@link http://www.ebyte.it/stan/Talk_ML_UserMeeting_SMASH_2010_GeneralizedLorentzian.html}
+ * {@link https://www.ebyte.it/stan/Talk_ML_UserMeeting_SMASH_2010_GeneralizedLorentzian.html}
  */
 export class GeneralizedLorentzian implements Shape1DClass {
   /**

--- a/src/shapes/1d/generalizedLorentzian/__tests__/GeneralizedLorentzian.derivative.test.ts
+++ b/src/shapes/1d/generalizedLorentzian/__tests__/GeneralizedLorentzian.derivative.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest';
+
+import {
+  GeneralizedLorentzian,
+  generalizedLorentzianDerivative,
+  generalizedLorentzianFct,
+} from '../GeneralizedLorentzian.ts';
+
+const fwhm = 0.3;
+const gamma = 0.6;
+const h = 1e-6;
+
+test('generalizedLorentzianDerivative matches numerical derivatives', () => {
+  for (const x of [-0.4, -0.1, 0, 0.05, 0.25]) {
+    const { fct, dx, dFwhm, dGamma } = generalizedLorentzianDerivative(
+      x,
+      fwhm,
+      gamma,
+    );
+
+    expect(fct).toBeCloseTo(generalizedLorentzianFct(x, fwhm, gamma), 12);
+
+    const numericalDx =
+      (generalizedLorentzianFct(x + h, fwhm, gamma) -
+        generalizedLorentzianFct(x - h, fwhm, gamma)) /
+      (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 6);
+
+    const numericalDFwhm =
+      (generalizedLorentzianFct(x, fwhm + h, gamma) -
+        generalizedLorentzianFct(x, fwhm - h, gamma)) /
+      (2 * h);
+
+    expect(dFwhm).toBeCloseTo(numericalDFwhm, 6);
+
+    const numericalDGamma =
+      (generalizedLorentzianFct(x, fwhm, gamma + h) -
+        generalizedLorentzianFct(x, fwhm, gamma - h)) /
+      (2 * h);
+
+    expect(dGamma).toBeCloseTo(numericalDGamma, 6);
+  }
+});
+
+test('GeneralizedLorentzian.derivative returns parameters in getParameters() order', () => {
+  const shape = new GeneralizedLorentzian({ fwhm, gamma });
+  const { fct, dx, parameters } = shape.derivative(0.05);
+  const expected = generalizedLorentzianDerivative(0.05, fwhm, gamma);
+
+  expect(shape.getParameters()).toStrictEqual(['fwhm', 'gamma']);
+  expect(fct).toBeCloseTo(expected.fct, 12);
+  expect(dx).toBeCloseTo(expected.dx, 12);
+  expect(parameters).toHaveLength(2);
+  expect(parameters[0]).toBeCloseTo(expected.dFwhm, 12);
+  expect(parameters[1]).toBeCloseTo(expected.dGamma, 12);
+});

--- a/src/shapes/1d/lorentzian/Lorentzian.ts
+++ b/src/shapes/1d/lorentzian/Lorentzian.ts
@@ -97,13 +97,13 @@ export const lorentzianFct = (x: number, fwhm: number) => {
  * @param fwhm - full width at half maximum.
  * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`) and `fwhm` (`dFwhm`).
  */
-export const lorentzianDerivative = (x: number, fwhm: number) => {
+export function lorentzianDerivative(x: number, fwhm: number) {
   const denominator = 4 * x * x + fwhm * fwhm;
   const fct = (fwhm * fwhm) / denominator;
   const dx = (-8 * x * fwhm * fwhm) / (denominator * denominator);
   const dFwhm = (8 * fwhm * x * x) / (denominator * denominator);
   return { fct, dx, dFwhm };
-};
+}
 
 export const lorentzianWidthToFWHM = (width: number) => {
   return width * ROOT_THREE;

--- a/src/shapes/1d/lorentzian/Lorentzian.ts
+++ b/src/shapes/1d/lorentzian/Lorentzian.ts
@@ -1,6 +1,10 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { Parameter, Shape1DClass } from '../Shape1DClass.ts';
+import type {
+  Parameter,
+  Shape1DClass,
+  Shape1DDerivative,
+} from '../Shape1DClass.ts';
 
 export interface LorentzianClassOptions {
   /**
@@ -67,6 +71,11 @@ export class Lorentzian implements Shape1DClass {
   public getParameters(): Parameter[] {
     return ['fwhm'];
   }
+
+  public derivative(x: number): Shape1DDerivative {
+    const { fct, dx, dFwhm } = lorentzianDerivative(x, this.fwhm);
+    return { fct, dx, parameters: [dFwhm] };
+  }
 }
 
 export const calculateLorentzianHeight = ({ fwhm = 1, area = 1 }) => {
@@ -80,6 +89,20 @@ export const getLorentzianArea = (options: GetLorentzianAreaOptions) => {
 
 export const lorentzianFct = (x: number, fwhm: number) => {
   return fwhm ** 2 / (4 * x ** 2 + fwhm ** 2);
+};
+
+/**
+ * Analytical value and partial derivatives of the lorentzian function centered at x=0.
+ * @param x - position at which to evaluate.
+ * @param fwhm - full width at half maximum.
+ * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`) and `fwhm` (`dFwhm`).
+ */
+export const lorentzianDerivative = (x: number, fwhm: number) => {
+  const denominator = 4 * x * x + fwhm * fwhm;
+  const fct = (fwhm * fwhm) / denominator;
+  const dx = (-8 * x * fwhm * fwhm) / (denominator * denominator);
+  const dFwhm = (8 * fwhm * x * x) / (denominator * denominator);
+  return { fct, dx, dFwhm };
 };
 
 export const lorentzianWidthToFWHM = (width: number) => {

--- a/src/shapes/1d/lorentzian/__tests__/Lorentzian.derivative.test.ts
+++ b/src/shapes/1d/lorentzian/__tests__/Lorentzian.derivative.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest';
+
+import {
+  Lorentzian,
+  lorentzianDerivative,
+  lorentzianFct,
+} from '../Lorentzian.ts';
+
+const fwhm = 0.3;
+const h = 1e-6;
+
+test('lorentzianDerivative matches numerical derivatives', () => {
+  for (const x of [-0.4, -0.1, 0, 0.05, 0.25]) {
+    const { fct, dx, dFwhm } = lorentzianDerivative(x, fwhm);
+
+    expect(fct).toBeCloseTo(lorentzianFct(x, fwhm), 12);
+
+    const numericalDx =
+      (lorentzianFct(x + h, fwhm) - lorentzianFct(x - h, fwhm)) / (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 6);
+
+    const numericalDFwhm =
+      (lorentzianFct(x, fwhm + h) - lorentzianFct(x, fwhm - h)) / (2 * h);
+
+    expect(dFwhm).toBeCloseTo(numericalDFwhm, 6);
+  }
+});
+
+test('Lorentzian.derivative returns parameters in getParameters() order', () => {
+  const lorentzian = new Lorentzian({ fwhm });
+  const { fct, dx, parameters } = lorentzian.derivative(0.05);
+  const expected = lorentzianDerivative(0.05, fwhm);
+
+  expect(lorentzian.getParameters()).toStrictEqual(['fwhm']);
+  expect(fct).toBeCloseTo(expected.fct, 12);
+  expect(dx).toBeCloseTo(expected.dx, 12);
+  expect(parameters).toHaveLength(1);
+  expect(parameters[0]).toBeCloseTo(expected.dFwhm, 12);
+});

--- a/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
+++ b/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
@@ -1,5 +1,9 @@
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { Parameter, Shape1DClass } from '../Shape1DClass.ts';
+import type {
+  Parameter,
+  Shape1DClass,
+  Shape1DDerivative,
+} from '../Shape1DClass.ts';
 import type { LorentzianClassOptions } from '../lorentzian/Lorentzian.ts';
 import {
   calculateLorentzianHeight,
@@ -52,10 +56,31 @@ export class LorentzianDispersive implements Shape1DClass {
   public getParameters(): Parameter[] {
     return ['fwhm'];
   }
+
+  public derivative(x: number): Shape1DDerivative {
+    const { fct, dx, dFwhm } = lorentzianDispersiveDerivative(x, this.fwhm);
+    return { fct, dx, parameters: [dFwhm] };
+  }
 }
 
 export const lorentzianDispersiveFct = (x: number, fwhm: number) => {
   return (2 * fwhm * x) / (4 * x ** 2 + fwhm ** 2);
+};
+
+/**
+ * Analytical value and partial derivatives of the dispersive lorentzian function centered at x=0.
+ * @param x - position at which to evaluate.
+ * @param fwhm - full width at half maximum.
+ * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`) and `fwhm` (`dFwhm`).
+ */
+export const lorentzianDispersiveDerivative = (x: number, fwhm: number) => {
+  const denominator = 4 * x * x + fwhm * fwhm;
+  const fct = (2 * fwhm * x) / denominator;
+  const dx =
+    (2 * fwhm * (fwhm * fwhm - 4 * x * x)) / (denominator * denominator);
+  const dFwhm =
+    (2 * x * (4 * x * x - fwhm * fwhm)) / (denominator * denominator);
+  return { fct, dx, dFwhm };
 };
 
 export const getLorentzianDispersiveData = (

--- a/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
+++ b/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
@@ -73,7 +73,7 @@ export const lorentzianDispersiveFct = (x: number, fwhm: number) => {
  * @param fwhm - full width at half maximum.
  * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`) and `fwhm` (`dFwhm`).
  */
-export const lorentzianDispersiveDerivative = (x: number, fwhm: number) => {
+export function lorentzianDispersiveDerivative(x: number, fwhm: number) {
   const denominator = 4 * x * x + fwhm * fwhm;
   const fct = (2 * fwhm * x) / denominator;
   const dx =
@@ -81,7 +81,7 @@ export const lorentzianDispersiveDerivative = (x: number, fwhm: number) => {
   const dFwhm =
     (2 * x * (4 * x * x - fwhm * fwhm)) / (denominator * denominator);
   return { fct, dx, dFwhm };
-};
+}
 
 export const getLorentzianDispersiveData = (
   shape: LorentzianClassOptions = {},

--- a/src/shapes/1d/lorentzianDispersive/__tests__/LorentzianDispersive.derivative.test.ts
+++ b/src/shapes/1d/lorentzianDispersive/__tests__/LorentzianDispersive.derivative.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'vitest';
+
+import {
+  LorentzianDispersive,
+  lorentzianDispersiveDerivative,
+  lorentzianDispersiveFct,
+} from '../LorentzianDispersive.ts';
+
+const fwhm = 0.3;
+const h = 1e-6;
+
+test('lorentzianDispersiveDerivative matches numerical derivatives', () => {
+  for (const x of [-0.4, -0.1, 0, 0.05, 0.25]) {
+    const { fct, dx, dFwhm } = lorentzianDispersiveDerivative(x, fwhm);
+
+    expect(fct).toBeCloseTo(lorentzianDispersiveFct(x, fwhm), 12);
+
+    const numericalDx =
+      (lorentzianDispersiveFct(x + h, fwhm) -
+        lorentzianDispersiveFct(x - h, fwhm)) /
+      (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 6);
+
+    const numericalDFwhm =
+      (lorentzianDispersiveFct(x, fwhm + h) -
+        lorentzianDispersiveFct(x, fwhm - h)) /
+      (2 * h);
+
+    expect(dFwhm).toBeCloseTo(numericalDFwhm, 6);
+  }
+});
+
+test('LorentzianDispersive.derivative returns parameters in getParameters() order', () => {
+  const shape = new LorentzianDispersive({ fwhm });
+  const { fct, dx, parameters } = shape.derivative(0.05);
+  const expected = lorentzianDispersiveDerivative(0.05, fwhm);
+
+  expect(shape.getParameters()).toStrictEqual(['fwhm']);
+  expect(fct).toBeCloseTo(expected.fct, 12);
+  expect(dx).toBeCloseTo(expected.dx, 12);
+  expect(parameters).toHaveLength(1);
+  expect(parameters[0]).toBeCloseTo(expected.dFwhm, 12);
+});

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -4,7 +4,11 @@ import {
   ROOT_PI_OVER_LN2,
 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { Parameter, Shape1DClass } from '../Shape1DClass.ts';
+import type {
+  Parameter,
+  Shape1DClass,
+  Shape1DDerivative,
+} from '../Shape1DClass.ts';
 import { gaussianFct } from '../gaussian/Gaussian.ts';
 import { lorentzianFct } from '../lorentzian/Lorentzian.ts';
 
@@ -111,6 +115,15 @@ export class PseudoVoigt implements Shape1DClass {
   public getParameters(): Parameter[] {
     return ['fwhm', 'mu'];
   }
+
+  public derivative(x: number): Shape1DDerivative {
+    const { fct, dx, dFwhm, dMu } = pseudoVoigtDerivative(
+      x,
+      this.fwhm,
+      this.mu,
+    );
+    return { fct, dx, parameters: [dFwhm, dMu] };
+  }
 }
 
 export const calculatePseudoVoigtHeight = (
@@ -122,6 +135,33 @@ export const calculatePseudoVoigtHeight = (
 
 export const pseudoVoigtFct = (x: number, fwhm: number, mu: number) => {
   return (1 - mu) * lorentzianFct(x, fwhm) + mu * gaussianFct(x, fwhm);
+};
+
+/**
+ * Analytical value and partial derivatives of the pseudo-Voigt function centered at x=0.
+ * @param x - position at which to evaluate.
+ * @param fwhm - full width at half maximum.
+ * @param mu - ratio of gaussian contribution in the shape.
+ * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`), `fwhm` (`dFwhm`) and `mu` (`dMu`).
+ */
+export const pseudoVoigtDerivative = (x: number, fwhm: number, mu: number) => {
+  // gaussian and lorentzian derivative math is inlined (rather than calling
+  // gaussianDerivative / lorentzianDerivative) to allocate a single object on
+  // this hot path; the sub-calls would allocate three.
+  const e = Math.exp(GAUSSIAN_EXP_FACTOR * (x / fwhm) ** 2);
+  const denominator = 4 * x * x + fwhm * fwhm;
+  const lorentz = (fwhm * fwhm) / denominator;
+  const dEdt = ((2 * GAUSSIAN_EXP_FACTOR * x) / (fwhm * fwhm)) * e;
+  const dLdt = (-8 * x * fwhm * fwhm) / (denominator * denominator);
+  const dEdfwhm =
+    ((-2 * GAUSSIAN_EXP_FACTOR * x * x) / (fwhm * fwhm * fwhm)) * e;
+  const dLdfwhm = (8 * fwhm * x * x) / (denominator * denominator);
+  return {
+    fct: (1 - mu) * lorentz + mu * e,
+    dx: (1 - mu) * dLdt + mu * dEdt,
+    dFwhm: (1 - mu) * dLdfwhm + mu * dEdfwhm,
+    dMu: e - lorentz,
+  };
 };
 
 export const pseudoVoigtWidthToFWHM = (width: number, mu = 0.5) => {

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -144,7 +144,7 @@ export const pseudoVoigtFct = (x: number, fwhm: number, mu: number) => {
  * @param mu - ratio of gaussian contribution in the shape.
  * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`), `fwhm` (`dFwhm`) and `mu` (`dMu`).
  */
-export const pseudoVoigtDerivative = (x: number, fwhm: number, mu: number) => {
+export function pseudoVoigtDerivative(x: number, fwhm: number, mu: number) {
   // gaussian and lorentzian derivative math is inlined (rather than calling
   // gaussianDerivative / lorentzianDerivative) to allocate a single object on
   // this hot path; the sub-calls would allocate three.
@@ -162,7 +162,7 @@ export const pseudoVoigtDerivative = (x: number, fwhm: number, mu: number) => {
     dFwhm: (1 - mu) * dLdfwhm + mu * dEdfwhm,
     dMu: e - lorentz,
   };
-};
+}
 
 export const pseudoVoigtWidthToFWHM = (width: number, mu = 0.5) => {
   return width * (mu * ROOT_2LN2_MINUS_ONE + 1);

--- a/src/shapes/1d/pseudoVoigt/__tests__/PseudoVoigt.derivative.test.ts
+++ b/src/shapes/1d/pseudoVoigt/__tests__/PseudoVoigt.derivative.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest';
+
+import {
+  PseudoVoigt,
+  pseudoVoigtDerivative,
+  pseudoVoigtFct,
+} from '../PseudoVoigt.ts';
+
+const fwhm = 0.3;
+const mu = 0.4;
+const h = 1e-6;
+
+test('pseudoVoigtDerivative matches numerical derivatives', () => {
+  for (const x of [-0.4, -0.1, 0, 0.05, 0.25]) {
+    const { fct, dx, dFwhm, dMu } = pseudoVoigtDerivative(x, fwhm, mu);
+
+    expect(fct).toBeCloseTo(pseudoVoigtFct(x, fwhm, mu), 12);
+
+    const numericalDx =
+      (pseudoVoigtFct(x + h, fwhm, mu) - pseudoVoigtFct(x - h, fwhm, mu)) /
+      (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 6);
+
+    const numericalDFwhm =
+      (pseudoVoigtFct(x, fwhm + h, mu) - pseudoVoigtFct(x, fwhm - h, mu)) /
+      (2 * h);
+
+    expect(dFwhm).toBeCloseTo(numericalDFwhm, 6);
+
+    const numericalDMu =
+      (pseudoVoigtFct(x, fwhm, mu + h) - pseudoVoigtFct(x, fwhm, mu - h)) /
+      (2 * h);
+
+    expect(dMu).toBeCloseTo(numericalDMu, 6);
+  }
+});
+
+test('PseudoVoigt.derivative returns parameters in getParameters() order', () => {
+  const pseudoVoigt = new PseudoVoigt({ fwhm, mu });
+  const { fct, dx, parameters } = pseudoVoigt.derivative(0.05);
+  const expected = pseudoVoigtDerivative(0.05, fwhm, mu);
+
+  expect(pseudoVoigt.getParameters()).toStrictEqual(['fwhm', 'mu']);
+  expect(fct).toBeCloseTo(expected.fct, 12);
+  expect(dx).toBeCloseTo(expected.dx, 12);
+  expect(parameters).toHaveLength(2);
+  expect(parameters[0]).toBeCloseTo(expected.dFwhm, 12);
+  expect(parameters[1]).toBeCloseTo(expected.dMu, 12);
+});

--- a/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
@@ -189,11 +189,11 @@ export class PseudoVoigtTCH implements Shape1DClass {
  * @param fwhmL - full width at half maximum of the lorentzian component.
  * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`), `fwhmG` (`dFwhmG`) and `fwhmL` (`dFwhmL`).
  */
-export const pseudoVoigtTCHDerivative = (
+export function pseudoVoigtTCHDerivative(
   x: number,
   fwhmG: number,
   fwhmL: number,
-) => {
+) {
   const effectiveFwhm = computeEffectiveWidth(fwhmG, fwhmL);
   const w = effectiveFwhm ** 5; // the polynomial under the 1/5 power
 
@@ -258,7 +258,7 @@ export const pseudoVoigtTCHDerivative = (
     dFwhmG: dFwhm * dFwhmDfwhmG + dMu * dMuDfwhmG,
     dFwhmL: dFwhm * dFwhmDfwhmL + dMu * dMuDfwhmL,
   };
-};
+}
 
 /**
  * Compute the effective FWHM from gaussian and lorentzian component widths

--- a/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
@@ -1,5 +1,10 @@
+import { GAUSSIAN_EXP_FACTOR } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { Parameter, Shape1DClass } from '../Shape1DClass.ts';
+import type {
+  Parameter,
+  Shape1DClass,
+  Shape1DDerivative,
+} from '../Shape1DClass.ts';
 import {
   calculatePseudoVoigtHeight,
   getPseudoVoigtArea,
@@ -164,7 +169,96 @@ export class PseudoVoigtTCH implements Shape1DClass {
   public getParameters(): Parameter[] {
     return ['fwhmG', 'fwhmL'];
   }
+
+  public derivative(x: number): Shape1DDerivative {
+    const { fct, dx, dFwhmG, dFwhmL } = pseudoVoigtTCHDerivative(
+      x,
+      this._fwhmG,
+      this._fwhmL,
+    );
+    return { fct, dx, parameters: [dFwhmG, dFwhmL] };
+  }
 }
+
+/**
+ * Analytical value and partial derivatives of the TCH pseudo-Voigt function centered at x=0.
+ * The effective fwhm `F` and mixing `mu` are functions of `fwhmG` and `fwhmL`, so the
+ * derivatives chain `∂fct/∂F` and `∂fct/∂mu` through `∂F/∂·` and `∂mu/∂·`.
+ * @param x - position at which to evaluate.
+ * @param fwhmG - full width at half maximum of the gaussian component.
+ * @param fwhmL - full width at half maximum of the lorentzian component.
+ * @returns the value `fct` and its partial derivatives with respect to `x` (`dx`), `fwhmG` (`dFwhmG`) and `fwhmL` (`dFwhmL`).
+ */
+export const pseudoVoigtTCHDerivative = (
+  x: number,
+  fwhmG: number,
+  fwhmL: number,
+) => {
+  const effectiveFwhm = computeEffectiveWidth(fwhmG, fwhmL);
+  const w = effectiveFwhm ** 5; // the polynomial under the 1/5 power
+
+  // ∂w/∂fwhmG and ∂w/∂fwhmL (derivatives of the TCH width polynomial).
+  const dwDfwhmG =
+    5 * fwhmG ** 4 +
+    10.77076 * fwhmG ** 3 * fwhmL +
+    7.28529 * fwhmG ** 2 * fwhmL ** 2 +
+    8.94326 * fwhmG * fwhmL ** 3 +
+    0.07842 * fwhmL ** 4;
+  const dwDfwhmL =
+    2.69269 * fwhmG ** 4 +
+    4.85686 * fwhmG ** 3 * fwhmL +
+    13.41489 * fwhmG ** 2 * fwhmL ** 2 +
+    0.31368 * fwhmG * fwhmL ** 3 +
+    5 * fwhmL ** 4;
+
+  // F = w^0.2  =>  ∂F/∂· = 0.2 * F / w * ∂w/∂·
+  const dFwhmDfwhmG = (0.2 * effectiveFwhm * dwDfwhmG) / w;
+  const dFwhmDfwhmL = (0.2 * effectiveFwhm * dwDfwhmL) / w;
+
+  // lorentzian width fraction L = fwhmL / F
+  const lorentzianFraction = fwhmL / effectiveFwhm;
+  const dLorentzianFractionDfwhmG =
+    (-fwhmL / (effectiveFwhm * effectiveFwhm)) * dFwhmDfwhmG;
+  const dLorentzianFractionDfwhmL =
+    1 / effectiveFwhm - (fwhmL / (effectiveFwhm * effectiveFwhm)) * dFwhmDfwhmL;
+
+  // mu = 1 - (1.36603 L - 0.47719 L^2 + 0.11116 L^3)
+  const dPolyDfraction =
+    1.36603 -
+    0.95438 * lorentzianFraction +
+    0.33348 * lorentzianFraction * lorentzianFraction;
+  const dMuDfwhmG = -dPolyDfraction * dLorentzianFractionDfwhmG;
+  const dMuDfwhmL = -dPolyDfraction * dLorentzianFractionDfwhmL;
+
+  const mu =
+    1 -
+    (1.36603 * lorentzianFraction -
+      0.47719 * lorentzianFraction * lorentzianFraction +
+      0.11116 * lorentzianFraction * lorentzianFraction * lorentzianFraction);
+
+  // pseudoVoigt value and its ∂/∂x, ∂/∂F (dFwhm), ∂/∂mu (dMu) at the effective
+  // fwhm, inlined to allocate a single object on this hot path.
+  const e = Math.exp(GAUSSIAN_EXP_FACTOR * (x / effectiveFwhm) ** 2);
+  const denominator2 = 4 * x * x + effectiveFwhm * effectiveFwhm;
+  const lorentz = (effectiveFwhm * effectiveFwhm) / denominator2;
+  const dEdt =
+    ((2 * GAUSSIAN_EXP_FACTOR * x) / (effectiveFwhm * effectiveFwhm)) * e;
+  const dLdt =
+    (-8 * x * effectiveFwhm * effectiveFwhm) / (denominator2 * denominator2);
+  const dEdfwhm =
+    ((-2 * GAUSSIAN_EXP_FACTOR * x * x) /
+      (effectiveFwhm * effectiveFwhm * effectiveFwhm)) *
+    e;
+  const dLdfwhm = (8 * effectiveFwhm * x * x) / (denominator2 * denominator2);
+  const dFwhm = (1 - mu) * dLdfwhm + mu * dEdfwhm;
+  const dMu = e - lorentz;
+  return {
+    fct: (1 - mu) * lorentz + mu * e,
+    dx: (1 - mu) * dLdt + mu * dEdt,
+    dFwhmG: dFwhm * dFwhmDfwhmG + dMu * dMuDfwhmG,
+    dFwhmL: dFwhm * dFwhmDfwhmL + dMu * dMuDfwhmL,
+  };
+};
 
 /**
  * Compute the effective FWHM from gaussian and lorentzian component widths

--- a/src/shapes/1d/pseudoVoigtTCH/__tests__/PseudoVoigtTCH.derivative.test.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/__tests__/PseudoVoigtTCH.derivative.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'vitest';
+
+import { PseudoVoigtTCH, pseudoVoigtTCHDerivative } from '../PseudoVoigtTCH.ts';
+
+const fwhmG = 0.3;
+const fwhmL = 0.4;
+const h = 1e-6;
+
+/**
+ * Effective fct(x) of a TCH pseudo-Voigt built from independent component widths.
+ * @param x
+ * @param g
+ * @param l
+ */
+function tchFct(x: number, g: number, l: number): number {
+  return new PseudoVoigtTCH({ fwhmG: g, fwhmL: l }).fct(x);
+}
+
+test('pseudoVoigtTCHDerivative matches numerical derivatives', () => {
+  for (const x of [-0.4, -0.1, 0, 0.05, 0.25]) {
+    const { fct, dx, dFwhmG, dFwhmL } = pseudoVoigtTCHDerivative(
+      x,
+      fwhmG,
+      fwhmL,
+    );
+
+    expect(fct).toBeCloseTo(tchFct(x, fwhmG, fwhmL), 12);
+
+    const numericalDx =
+      (tchFct(x + h, fwhmG, fwhmL) - tchFct(x - h, fwhmG, fwhmL)) / (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 6);
+
+    const numericalDFwhmG =
+      (tchFct(x, fwhmG + h, fwhmL) - tchFct(x, fwhmG - h, fwhmL)) / (2 * h);
+
+    expect(dFwhmG).toBeCloseTo(numericalDFwhmG, 5);
+
+    const numericalDFwhmL =
+      (tchFct(x, fwhmG, fwhmL + h) - tchFct(x, fwhmG, fwhmL - h)) / (2 * h);
+
+    expect(dFwhmL).toBeCloseTo(numericalDFwhmL, 5);
+  }
+});
+
+test('PseudoVoigtTCH.derivative returns parameters in getParameters() order', () => {
+  const shape = new PseudoVoigtTCH({ fwhmG, fwhmL });
+  const { fct, dx, parameters } = shape.derivative(0.05);
+  const expected = pseudoVoigtTCHDerivative(0.05, fwhmG, fwhmL);
+
+  expect(shape.getParameters()).toStrictEqual(['fwhmG', 'fwhmL']);
+  expect(fct).toBeCloseTo(expected.fct, 12);
+  expect(dx).toBeCloseTo(expected.dx, 12);
+  expect(parameters).toHaveLength(2);
+  expect(parameters[0]).toBeCloseTo(expected.dFwhmG, 12);
+  expect(parameters[1]).toBeCloseTo(expected.dFwhmL, 12);
+});


### PR DESCRIPTION
## What

Adds an analytical `derivative(x)` to every `Shape1D` class plus standalone `<shape>Derivative(...)` functions, so consumers can build an exact Jacobian instead of approximating it with finite differences.

- New required `Shape1DClass.derivative(x)` returning `{ fct, dx, parameters }`, where `parameters` are the partials w.r.t. each shape parameter in `getParameters()` order. Exposed via the new exported `Shape1DDerivative` type.
- Standalone functions next to each `fct`: `gaussianDerivative`, `lorentzianDerivative`, `pseudoVoigtDerivative`, `lorentzianDispersiveDerivative`, `generalizedLorentzianDerivative`, `pseudoVoigtTCHDerivative`.
- `pseudoVoigtDerivative` and `pseudoVoigtTCHDerivative` inline their component math so the hot path allocates a single object (instead of 3 / 2).

## Why

`ml-spectra-fitting`'s `optimize()` can pass these as an analytical `jacobianFunction` to Levenberg–Marquardt. Measured end-to-end speedup vs the current finite-difference behavior: ~4× (mixed shapes, 42 params) to ~5.8× (all pseudoVoigt, 48 params), same iteration count and final error.

## Tests

Each derivative is validated against central finite differences, and each class's `derivative()` is checked to return parameters in `getParameters()` order. `npm test` passes (108 tests, lint, types, prettier).

> Note: requires a release of `ml-levenberg-marquardt` with `jacobianFunction` support for the downstream analytical-Jacobian path to take effect.