### PR TITLE
refactor: return specific parameter tuples from getParameters()

### DIFF
--- a/src/shapes/1d/Shape1DClass.ts
+++ b/src/shapes/1d/Shape1DClass.ts
@@ -4,6 +4,14 @@ import type { GetData1DOptions } from './GetData1DOptions.ts';
 
 export type Parameter = 'fwhm' | 'mu' | 'gamma' | 'fwhmG' | 'fwhmL';
 
+/**
+ * The exact tuple of parameters a shape exposes. Constraining `T` to
+ * `readonly Parameter[]` keeps each shape's precise tuple type while
+ * guaranteeing every entry is a valid `Parameter`, so renaming or removing a
+ * member of `Parameter` breaks any shape that still lists it.
+ */
+export type ParameterTuple<T extends readonly Parameter[]> = T;
+
 export interface Shape1DDerivative {
   /** Value of `fct(x)`. */
   fct: number;

--- a/src/shapes/1d/gaussian/Gaussian.ts
+++ b/src/shapes/1d/gaussian/Gaussian.ts
@@ -6,7 +6,7 @@ import {
 import erfinv from '../../../util/erfinv.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
-  Parameter,
+  ParameterTuple,
   Shape1DClass,
   Shape1DDerivative,
 } from '../Shape1DClass.ts';
@@ -95,7 +95,7 @@ export class Gaussian implements Shape1DClass {
     return calculateGaussianHeight({ fwhm: this.fwhm, area });
   }
 
-  public getParameters(): Parameter[] {
+  public getParameters(): ParameterTuple<['fwhm']> {
     return ['fwhm'];
   }
 

--- a/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
+++ b/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
@@ -1,7 +1,7 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
-  Parameter,
+  ParameterTuple,
   Shape1DClass,
   Shape1DDerivative,
 } from '../Shape1DClass.ts';
@@ -92,7 +92,7 @@ export class GeneralizedLorentzian implements Shape1DClass {
     return calculateGeneralizedLorentzianHeight({ fwhm, area, gamma });
   }
 
-  public getParameters(): Parameter[] {
+  public getParameters(): ParameterTuple<['fwhm', 'gamma']> {
     return ['fwhm', 'gamma'];
   }
 

--- a/src/shapes/1d/lorentzian/Lorentzian.ts
+++ b/src/shapes/1d/lorentzian/Lorentzian.ts
@@ -1,7 +1,7 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
-  Parameter,
+  ParameterTuple,
   Shape1DClass,
   Shape1DDerivative,
 } from '../Shape1DClass.ts';
@@ -68,7 +68,7 @@ export class Lorentzian implements Shape1DClass {
     return calculateLorentzianHeight({ fwhm: this.fwhm, area });
   }
 
-  public getParameters(): Parameter[] {
+  public getParameters(): ParameterTuple<['fwhm']> {
     return ['fwhm'];
   }
 

--- a/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
+++ b/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
@@ -1,6 +1,6 @@
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
-  Parameter,
+  ParameterTuple,
   Shape1DClass,
   Shape1DDerivative,
 } from '../Shape1DClass.ts';
@@ -53,7 +53,7 @@ export class LorentzianDispersive implements Shape1DClass {
     return calculateLorentzianHeight({ fwhm: this.fwhm, area });
   }
 
-  public getParameters(): Parameter[] {
+  public getParameters(): ParameterTuple<['fwhm']> {
     return ['fwhm'];
   }
 

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
-  Parameter,
+  ParameterTuple,
   Shape1DClass,
   Shape1DDerivative,
 } from '../Shape1DClass.ts';
@@ -112,7 +112,7 @@ export class PseudoVoigt implements Shape1DClass {
     return calculatePseudoVoigtHeight({ fwhm: this.fwhm, mu: this.mu, area });
   }
 
-  public getParameters(): Parameter[] {
+  public getParameters(): ParameterTuple<['fwhm', 'mu']> {
     return ['fwhm', 'mu'];
   }
 

--- a/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
@@ -1,7 +1,7 @@
 import { GAUSSIAN_EXP_FACTOR } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
-  Parameter,
+  ParameterTuple,
   Shape1DClass,
   Shape1DDerivative,
 } from '../Shape1DClass.ts';
@@ -166,7 +166,7 @@ export class PseudoVoigtTCH implements Shape1DClass {
     });
   }
 
-  public getParameters(): Parameter[] {
+  public getParameters(): ParameterTuple<['fwhmG', 'fwhmL']> {
     return ['fwhmG', 'fwhmL'];
   }
 


### PR DESCRIPTION
Each shape now declares its exact parameter tuple (e.g. `['fwhm', 'mu']`) via a new `ParameterTuple<T extends readonly Parameter[]>` helper. Callers get precise types, and removing or renaming a `Parameter` is caught at compile time. The `Shape1DClass` interface contract is unchanged.