### PR TITLE
perf: skip the pseudo-Voigt gaussian half where it has underflowed

### DIFF
--- a/benchmark/pseudoVoigt.js
+++ b/benchmark/pseudoVoigt.js
@@ -1,5 +1,7 @@
 import Benchmark from 'benchmark';
 
+import { pseudoVoigtFct } from '../src/shapes/1d/pseudoVoigt/PseudoVoigt.ts';
+
 /**
  * A pseudo-Voigt is `(1 - mu) * lorentzian + mu * gaussian`, and a renderer
  * evaluates it over a whole window. The gaussian half underflows a few line
@@ -85,26 +87,46 @@ function sweepGuarded() {
   return total;
 }
 
+/**
+ * Sum the shape the package actually exports, so the benchmark measures the
+ * library rather than a transcription of it.
+ * @returns the sum.
+ */
+function sweepLibrary() {
+  let total = 0;
+  for (let index = 0; index < SIZE; index++) {
+    total += pseudoVoigtFct(positions[index], FWHM, MU);
+  }
+  return total;
+}
+
 const currentTotal = sweepCurrent();
 const guardedTotal = sweepGuarded();
+const libraryTotal = sweepLibrary();
+if (libraryTotal !== currentTotal) {
+  throw new Error('the library no longer agrees with the reference sweep');
+}
 // eslint-disable-next-line no-console
 console.log(
   `sum over ${SIZE} points  current ${currentTotal.toPrecision(17)}  guarded ${guardedTotal.toPrecision(17)}  difference ${Math.abs(currentTotal - guardedTotal).toExponential(2)}`,
 );
 
-new Benchmark.Suite()
+const suite = new Benchmark.Suite();
+
+suite
   .add('current', sweepCurrent, { minSamples: 30 })
   .add('guarded', sweepGuarded, { minSamples: 30 })
+  .add('library', sweepLibrary, { minSamples: 30 })
   .on('cycle', (event) => {
     const { name, hz, stats } = event.target;
     const nsPerPoint = (1e9 / hz / SIZE).toFixed(2);
     // eslint-disable-next-line no-console
     console.log(
-      `${name.padEnd(8)} ${(hz * SIZE / 1e6).toFixed(1).padStart(7)} Mpoints/s  ${nsPerPoint.padStart(6)} ns/point  +-${stats.rme.toFixed(2)}%`,
+      `${name.padEnd(8)} ${((hz * SIZE) / 1e6).toFixed(1).padStart(7)} Mpoints/s  ${nsPerPoint.padStart(6)} ns/point  +-${stats.rme.toFixed(2)}%`,
     );
   })
-  .on('complete', function onComplete() {
+  .on('complete', () => {
     // eslint-disable-next-line no-console
-    console.log(`fastest: ${this.filter('fastest').map('name').join(', ')}`);
+    console.log(`fastest: ${suite.filter('fastest').map('name').join(', ')}`);
   })
   .run();

--- a/benchmark/pseudoVoigt.js
+++ b/benchmark/pseudoVoigt.js
@@ -1,0 +1,110 @@
+import Benchmark from 'benchmark';
+
+/**
+ * A pseudo-Voigt is `(1 - mu) * lorentzian + mu * gaussian`, and a renderer
+ * evaluates it over a whole window. The gaussian half underflows a few line
+ * widths from the centre while the lorentzian half does not, so every point past
+ * that pays for a `Math.exp` whose result cannot change the sum.
+ *
+ * This benchmark evaluates both halves over a window of the width a spectrum
+ * generator actually uses — `getFactor()` returns 6366 line widths for a
+ * lorentzian-dominated shape — and compares the current implementation with one
+ * that skips the gaussian half where it has underflowed.
+ *
+ * Run with `node benchmark/pseudoVoigt.js`.
+ */
+
+const GAUSSIAN_EXP_FACTOR = -4 * Math.LN2;
+
+/** Beyond this z², `exp(GAUSSIAN_EXP_FACTOR * z²)` is below 1.4e-17. */
+const GAUSSIAN_CUTOFF = 14;
+
+/**
+ * The current implementation, copied so both variants are measured in one
+ * process against the same data.
+ * @param x - distance from the centre.
+ * @param fwhm - full width at half maximum.
+ * @param mu - ratio of gaussian contribution.
+ * @returns the value of the shape.
+ */
+function currentFct(x, fwhm, mu) {
+  const lorentzian = fwhm ** 2 / (4 * x ** 2 + fwhm ** 2);
+  const gaussian = Math.exp(GAUSSIAN_EXP_FACTOR * (x / fwhm) ** 2);
+  return (1 - mu) * lorentzian + mu * gaussian;
+}
+
+/**
+ * The same shape, skipping the gaussian half where it has underflowed.
+ * @param x - distance from the centre.
+ * @param fwhm - full width at half maximum.
+ * @param mu - ratio of gaussian contribution.
+ * @returns the value of the shape.
+ */
+function guardedFct(x, fwhm, mu) {
+  const lorentzian = fwhm ** 2 / (4 * x ** 2 + fwhm ** 2);
+  const z = x / fwhm;
+  if (z * z > GAUSSIAN_CUTOFF) return (1 - mu) * lorentzian;
+  const gaussian = Math.exp(GAUSSIAN_EXP_FACTOR * z * z);
+  return (1 - mu) * lorentzian + mu * gaussian;
+}
+
+const FWHM = 1;
+const MU = 0.1;
+const SIZE = 100000;
+
+// positions spanning the window a generator renders for this shape
+const positions = new Float64Array(SIZE);
+for (let index = 0; index < SIZE; index++) {
+  positions[index] = ((index / SIZE) * 6366 - 3183) * FWHM;
+}
+
+// each variant gets its own sweep: a shared one would make the call site
+// polymorphic and the two cases would contaminate each other's inline caches
+
+/**
+ * Sum the current implementation over every position.
+ * @returns the sum.
+ */
+function sweepCurrent() {
+  let total = 0;
+  for (let index = 0; index < SIZE; index++) {
+    total += currentFct(positions[index], FWHM, MU);
+  }
+  return total;
+}
+
+/**
+ * Sum the guarded implementation over every position.
+ * @returns the sum.
+ */
+function sweepGuarded() {
+  let total = 0;
+  for (let index = 0; index < SIZE; index++) {
+    total += guardedFct(positions[index], FWHM, MU);
+  }
+  return total;
+}
+
+const currentTotal = sweepCurrent();
+const guardedTotal = sweepGuarded();
+// eslint-disable-next-line no-console
+console.log(
+  `sum over ${SIZE} points  current ${currentTotal.toPrecision(17)}  guarded ${guardedTotal.toPrecision(17)}  difference ${Math.abs(currentTotal - guardedTotal).toExponential(2)}`,
+);
+
+new Benchmark.Suite()
+  .add('current', sweepCurrent, { minSamples: 30 })
+  .add('guarded', sweepGuarded, { minSamples: 30 })
+  .on('cycle', (event) => {
+    const { name, hz, stats } = event.target;
+    const nsPerPoint = (1e9 / hz / SIZE).toFixed(2);
+    // eslint-disable-next-line no-console
+    console.log(
+      `${name.padEnd(8)} ${(hz * SIZE / 1e6).toFixed(1).padStart(7)} Mpoints/s  ${nsPerPoint.padStart(6)} ns/point  +-${stats.rme.toFixed(2)}%`,
+    );
+  })
+  .on('complete', function onComplete() {
+    // eslint-disable-next-line no-console
+    console.log(`fastest: ${this.filter('fastest').map('name').join(', ')}`);
+  })
+  .run();

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^22.15.29",
     "@vitest/coverage-v8": "^3.2.3",
     "@zakodium/tsconfig": "^1.0.5",
+    "benchmark": "^2.1.4",
     "compute-erfinv": "^3.0.1",
     "eslint": "^9.28.0",
     "eslint-config-cheminfo-typescript": "^22.0.0",

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -1,4 +1,5 @@
 import {
+  GAUSSIAN_CUTOFF,
   GAUSSIAN_EXP_FACTOR,
   ROOT_2LN2_MINUS_ONE,
   ROOT_PI_OVER_LN2,
@@ -134,7 +135,13 @@ export const calculatePseudoVoigtHeight = (
 };
 
 export const pseudoVoigtFct = (x: number, fwhm: number, mu: number) => {
-  return (1 - mu) * lorentzianFct(x, fwhm) + mu * gaussianFct(x, fwhm);
+  // at mu = 1 the shape *is* the gaussian: there is no lorentzian half left to
+  // carry the tail, so the gaussian is evaluated however far out it is asked for
+  if (mu === 1) return gaussianFct(x, fwhm);
+  const lorentzian = (1 - mu) * lorentzianFct(x, fwhm);
+  const z = x / fwhm;
+  if (z * z > GAUSSIAN_CUTOFF) return lorentzian;
+  return lorentzian + mu * gaussianFct(x, fwhm);
 };
 
 /**
@@ -148,7 +155,18 @@ export function pseudoVoigtDerivative(x: number, fwhm: number, mu: number) {
   // gaussian and lorentzian derivative math is inlined (rather than calling
   // gaussianDerivative / lorentzianDerivative) to allocate a single object on
   // this hot path; the sub-calls would allocate three.
-  const e = Math.exp(GAUSSIAN_EXP_FACTOR * (x / fwhm) ** 2);
+  //
+  // Past {@link GAUSSIAN_CUTOFF} the gaussian half has underflowed, so it is
+  // dropped here under the same condition as in `pseudoVoigtFct` — including its
+  // mu = 1 exemption, so the two stay consistent — which also settles what the
+  // derivatives are out there: `dx` and `dFwhm` keep only their lorentzian
+  // halves, and `dMu` becomes `-lorentz`, the value the shape loses by trading
+  // its lorentzian half for a gaussian one that contributes nothing.
+  const z = x / fwhm;
+  const e =
+    mu !== 1 && z * z > GAUSSIAN_CUTOFF
+      ? 0
+      : Math.exp(GAUSSIAN_EXP_FACTOR * z * z);
   const denominator = 4 * x * x + fwhm * fwhm;
   const lorentz = (fwhm * fwhm) / denominator;
   const dEdt = ((2 * GAUSSIAN_EXP_FACTOR * x) / (fwhm * fwhm)) * e;

--- a/src/shapes/1d/pseudoVoigt/__tests__/PseudoVoigt.cutoff.test.ts
+++ b/src/shapes/1d/pseudoVoigt/__tests__/PseudoVoigt.cutoff.test.ts
@@ -1,0 +1,113 @@
+import { expect, test } from 'vitest';
+
+import { GAUSSIAN_EXP_FACTOR } from '../../../../util/constants.ts';
+import { gaussianFct } from '../../gaussian/Gaussian.ts';
+import { lorentzianFct } from '../../lorentzian/Lorentzian.ts';
+import { pseudoVoigtDerivative, pseudoVoigtFct } from '../PseudoVoigt.ts';
+
+/**
+ * The shape with its gaussian half always evaluated, which is what the guarded
+ * implementation has to agree with.
+ * @param x - distance from the centre.
+ * @param fwhm - full width at half maximum.
+ * @param mu - ratio of gaussian contribution.
+ * @returns the value of the shape.
+ */
+function unguarded(x: number, fwhm: number, mu: number): number {
+  return (
+    (1 - mu) * lorentzianFct(x, fwhm) +
+    mu * Math.exp(GAUSSIAN_EXP_FACTOR * (x / fwhm) ** 2)
+  );
+}
+
+const MU_VALUES = [0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99, 1];
+
+test('dropping the underflowed gaussian half is below double precision', () => {
+  const fwhm = 0.3;
+  let largest = 0;
+  for (const mu of MU_VALUES) {
+    for (let z = 0; z <= 60; z += 0.01) {
+      const x = z * fwhm;
+      const difference = Math.abs(
+        pseudoVoigtFct(x, fwhm, mu) - unguarded(x, fwhm, mu),
+      );
+      if (difference > largest) largest = difference;
+    }
+  }
+
+  // the shape is one at its centre, so this is a relative bound too
+  expect(largest).toBeLessThan(1.5e-17);
+});
+
+test('the shape is unchanged where the gaussian half still matters', () => {
+  const fwhm = 0.3;
+  for (const mu of MU_VALUES) {
+    for (let z = 0; z <= 3.7; z += 0.01) {
+      const x = z * fwhm;
+
+      expect(pseudoVoigtFct(x, fwhm, mu)).toBe(unguarded(x, fwhm, mu));
+    }
+  }
+});
+
+test('the cutoff is symmetric', () => {
+  const fwhm = 0.3;
+  for (const mu of MU_VALUES) {
+    for (const z of [3.6, 3.75, 4, 10, 50]) {
+      expect(pseudoVoigtFct(z * fwhm, fwhm, mu)).toBe(
+        pseudoVoigtFct(-z * fwhm, fwhm, mu),
+      );
+    }
+  }
+});
+
+test('the derivative agrees with the shape past the cutoff', () => {
+  const fwhm = 0.3;
+  for (const mu of MU_VALUES) {
+    for (const z of [3.8, 5, 20, 100]) {
+      const x = z * fwhm;
+      const { fct, dMu } = pseudoVoigtDerivative(x, fwhm, mu);
+      // with no gaussian left, trading lorentzian for gaussian costs -lorentz;
+      // the pure gaussian is exempt from the cutoff, so its half is still there
+      const expectedDMu =
+        (mu === 1 ? gaussianFct(x, fwhm) : 0) - lorentzianFct(x, fwhm);
+
+      expect(fct).toBe(pseudoVoigtFct(x, fwhm, mu));
+      expect(dMu).toBe(expectedDMu);
+    }
+  }
+});
+
+test('the derivative still matches finite differences past the cutoff', () => {
+  const fwhm = 0.3;
+  const mu = 0.4;
+  const h = 1e-6;
+  for (const z of [4, 6, 12]) {
+    const x = z * fwhm;
+    const { dx, dFwhm } = pseudoVoigtDerivative(x, fwhm, mu);
+    const numericalDx =
+      (pseudoVoigtFct(x + h, fwhm, mu) - pseudoVoigtFct(x - h, fwhm, mu)) /
+      (2 * h);
+    const numericalDFwhm =
+      (pseudoVoigtFct(x, fwhm + h, mu) - pseudoVoigtFct(x, fwhm - h, mu)) /
+      (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 10);
+    expect(dFwhm).toBeCloseTo(numericalDFwhm, 10);
+  }
+});
+
+test('a pure gaussian is never cut off', () => {
+  const fwhm = 0.3;
+  for (const z of [0, 1, 3.7, 3.8, 5, 20]) {
+    const x = z * fwhm;
+
+    expect(pseudoVoigtFct(x, fwhm, 1)).toBe(gaussianFct(x, fwhm));
+  }
+
+  // it is the only mixing at which the tail survives past the cutoff
+  expect(pseudoVoigtFct(5 * fwhm, fwhm, 1)).toBeGreaterThan(0);
+  expect(pseudoVoigtFct(5 * fwhm, fwhm, 0.99)).toBe(
+    (1 - 0.99) * lorentzianFct(5 * fwhm, fwhm),
+  );
+});

--- a/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
@@ -1,4 +1,7 @@
-import { GAUSSIAN_EXP_FACTOR } from '../../../util/constants.ts';
+import {
+  GAUSSIAN_CUTOFF,
+  GAUSSIAN_EXP_FACTOR,
+} from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
 import type {
   ParameterTuple,
@@ -238,7 +241,16 @@ export function pseudoVoigtTCHDerivative(
 
   // pseudoVoigt value and its ∂/∂x, ∂/∂F (dFwhm), ∂/∂mu (dMu) at the effective
   // fwhm, inlined to allocate a single object on this hot path.
-  const e = Math.exp(GAUSSIAN_EXP_FACTOR * (x / effectiveFwhm) ** 2);
+  //
+  // Past {@link GAUSSIAN_CUTOFF} the gaussian half has underflowed and is
+  // dropped under the same condition as in `pseudoVoigtFct` — which this shape's
+  // own `fct` delegates to, so the value and its derivatives stay consistent out
+  // there. `fwhmL = 0` gives `mu = 1`, the pure gaussian that is never dropped.
+  const z = x / effectiveFwhm;
+  const e =
+    mu !== 1 && z * z > GAUSSIAN_CUTOFF
+      ? 0
+      : Math.exp(GAUSSIAN_EXP_FACTOR * z * z);
   const denominator2 = 4 * x * x + effectiveFwhm * effectiveFwhm;
   const lorentz = (effectiveFwhm * effectiveFwhm) / denominator2;
   const dEdt =

--- a/src/shapes/1d/pseudoVoigtTCH/__tests__/PseudoVoigtTCH.derivative.test.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/__tests__/PseudoVoigtTCH.derivative.test.ts
@@ -55,3 +55,40 @@ test('PseudoVoigtTCH.derivative returns parameters in getParameters() order', ()
   expect(parameters[0]).toBeCloseTo(expected.dFwhmG, 12);
   expect(parameters[1]).toBeCloseTo(expected.dFwhmL, 12);
 });
+
+test('the derivative stays consistent with the shape past the gaussian cutoff', () => {
+  const fwhmG = 0.2;
+  const fwhmL = 0.3;
+  const shape = new PseudoVoigtTCH({ fwhmG, fwhmL });
+  const h = 1e-7;
+  for (const z of [4, 6, 12, 40]) {
+    const x = z * shape.fwhm;
+    const { fct, dx } = pseudoVoigtTCHDerivative(x, fwhmG, fwhmL);
+
+    // the value keeps agreeing with `fct`, which drops the same underflowed half
+    expect(fct).toBe(shape.fct(x));
+
+    const numericalDx =
+      (pseudoVoigtTCHDerivative(x + h, fwhmG, fwhmL).fct -
+        pseudoVoigtTCHDerivative(x - h, fwhmG, fwhmL).fct) /
+      (2 * h);
+
+    expect(dx).toBeCloseTo(numericalDx, 10);
+  }
+});
+
+test('a shape with no lorentzian width keeps its gaussian half past the cutoff', () => {
+  const shape = new PseudoVoigtTCH({ fwhm: 0.2 });
+  shape.mu = 1;
+
+  expect(shape.fwhmL).toBe(0);
+
+  for (const z of [4, 6, 12]) {
+    const x = z * shape.fwhm;
+    const { fct } = pseudoVoigtTCHDerivative(x, shape.fwhmG, shape.fwhmL);
+
+    expect(fct).toBeGreaterThan(0);
+    // the derivative rebuilds the effective fwhm, so it agrees to rounding only
+    expect(fct / shape.fct(x)).toBeCloseTo(1, 10);
+  }
+});

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,4 +1,19 @@
 export const GAUSSIAN_EXP_FACTOR = -4 * Math.LN2;
+
+/**
+ * A pseudo-Voigt is a gaussian plus a lorentzian. Beyond 3.74 fwhm from the
+ * centre the gaussian part is down to 1.4e-17 — too small to change a shape of
+ * height one — while the lorentzian part is still 1.8e-2 and fades much more
+ * slowly. Past that distance the gaussian is skipped: the `Math.exp` it costs
+ * cannot change the result, and most points of a wide window lie out there.
+ *
+ * The limit is stored squared, so the test is `(x / fwhm)² > 14`, which saves a
+ * square root. The same value works for every mixing ratio `mu`, except `mu = 1`
+ * where the shape is a pure gaussian: with no lorentzian part left, skipping
+ * would return zero instead of a very small number, so that case is never
+ * skipped.
+ */
+export const GAUSSIAN_CUTOFF = 14;
 export const ROOT_PI_OVER_LN2 = Math.sqrt(Math.PI / Math.LN2);
 export const ROOT_THREE = Math.sqrt(3);
 export const ROOT_2LN2 = Math.sqrt(2 * Math.LN2);


### PR DESCRIPTION
A pseudo-Voigt is `(1 - mu) * lorentzian + mu * gaussian`. The gaussian half falls off as `exp(-4 ln2 z²)` and the lorentzian half only as `1/z²`, so a few line widths from the centre the gaussian term can no longer change the result while the lorentzian one still carries the shape. A renderer nevertheless sweeps the window a generator asks for — for a lorentzian-dominated shape that is the 6366 line widths `getFactor()` returns — so nearly every point evaluated pays for a `Math.exp` that contributes nothing.

Past `z² = 14` the gaussian term is below `1.4e-17` and is dropped.

**Why the bound does not depend on `mu`.** The term is `mu · exp(-4 ln2 z²)`, so the distance at which it stops mattering moves with `ln(mu)`: it spans only `z² = 12.2` (`mu = 0.05`) to `13.3` (`mu = 1`). A single constant sized for the worst case is correct for every shape.

**Why `mu = 1` is exempt.** Such a shape is a pure gaussian with no lorentzian half to fall back on, so dropping the term would replace the whole value by `0` past `3.74` line widths rather than perturb a sum below its precision, and would make it disagree with `Gaussian`, which has no cutoff. It returns `gaussianFct` directly, which is bit-identical to the previous implementation there: `(1 - mu) * lorentzian` is exactly zero and `mu * gaussian` exactly the gaussian.

Both shapes are covered. `PseudoVoigtTCH.fct` already delegates to `pseudoVoigtFct`, and `pseudoVoigtDerivative` / `pseudoVoigtTCHDerivative` drop the term under the same condition — which also settles the derivatives out there: `dx` and `dFwhm` keep only their lorentzian halves, and `dMu` becomes `-lorentz`. `fwhmL = 0` gives `mu` exactly one, so the TCH shape stays consistent between value and derivative at every mixing too.

Measured on an Apple M2 Pro, node 24, 100000 points, `mu = 0.1` (`node benchmark/pseudoVoigt.js`):

| | ns/point |
|---|---|
| before | 7.04 – 8.17 |
| after | 3.06 – 3.35 |

The summed sweep is bit-identical before and after.
