### PR TITLE
refactor: give each shape its own parameter type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ bower_components
 build/Release
 
 # Dependency directories
-node_modules/
+node_modules
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/lpatiny/git/mljs/peak-shape-generator/node_modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export type { GaussianShape2D, Shape2D } from './shapes/2d/Shape2D.ts';
 export type {
   Shape1DClass,
   Shape1DDerivative,
+  Shape1DParameter,
 } from './shapes/1d/Shape1DClass.ts';
 export type { Shape2DClass } from './shapes/2d/Shape2DClass.ts';
 export type { Shape1DInstance } from './shapes/1d/Shape1DInstance.ts';

--- a/src/shapes/1d/Shape1DClass.ts
+++ b/src/shapes/1d/Shape1DClass.ts
@@ -1,17 +1,29 @@
 import type { DoubleArray } from 'cheminfo-types';
 
 import type { GetData1DOptions } from './GetData1DOptions.ts';
-
-export type Parameter =
-  'fwhm' | 'mu' | 'gamma' | 'fwhmG' | 'fwhmL' | 'fwhmLow' | 'fwhmHigh';
+import type { GaussianParameter } from './gaussian/Gaussian.ts';
+import type { GeneralizedLorentzianParameter } from './generalizedLorentzian/GeneralizedLorentzian.ts';
+import type { LorentzianParameter } from './lorentzian/Lorentzian.ts';
+import type { LorentzianDispersiveParameter } from './lorentzianDispersive/LorentzianDispersive.ts';
+import type { PseudoVoigtParameter } from './pseudoVoigt/PseudoVoigt.ts';
+import type { PseudoVoigtTCHParameter } from './pseudoVoigtTCH/PseudoVoigtTCH.ts';
+import type { SplitGaussianParameter } from './splitGaussian/SplitGaussian.ts';
 
 /**
- * The exact tuple of parameters a shape exposes. Constraining `T` to
- * `readonly Parameter[]` keeps each shape's precise tuple type while
- * guaranteeing every entry is a valid `Parameter`, so renaming or removing a
- * member of `Parameter` breaks any shape that still lists it.
+ * Every parameter a 1D shape can expose: the combination of the parameters of
+ * all the shapes. Indexing a tuple of them, rather than writing a union,
+ * because shapes that share a parameter would make duplicate union
+ * constituents.
  */
-export type ParameterTuple<T extends readonly Parameter[]> = T;
+export type Shape1DParameter = [
+  GaussianParameter,
+  GeneralizedLorentzianParameter,
+  LorentzianParameter,
+  LorentzianDispersiveParameter,
+  PseudoVoigtParameter,
+  PseudoVoigtTCHParameter,
+  SplitGaussianParameter,
+][number];
 
 export interface Shape1DDerivative {
   /** Value of `fct(x)`. */
@@ -67,7 +79,7 @@ export interface Shape1DClass {
   /**
    * Returns an array of the different parameters characterizing the shape
    */
-  getParameters(): Parameter[];
+  getParameters(): Shape1DParameter[];
   /**
    * Analytical partial derivatives of `fct` at `x`, with respect to `x` and to
    * each shape parameter (in the same order as `getParameters()`). Every shape

--- a/src/shapes/1d/gaussian/Gaussian.ts
+++ b/src/shapes/1d/gaussian/Gaussian.ts
@@ -5,11 +5,7 @@ import {
 } from '../../../util/constants.ts';
 import erfinv from '../../../util/erfinv.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 
 interface CalculateGaussianHeightOptions {
   /**
@@ -95,7 +91,7 @@ export class Gaussian implements Shape1DClass {
     return calculateGaussianHeight({ fwhm: this.fwhm, area });
   }
 
-  public getParameters(): ParameterTuple<['fwhm']> {
+  public getParameters(): GaussianParameter[] {
     return ['fwhm'];
   }
 
@@ -104,6 +100,9 @@ export class Gaussian implements Shape1DClass {
     return { fct, dx, parameters: [dFwhm] };
   }
 }
+
+/** Parameters characterizing a gaussian shape. */
+export type GaussianParameter = 'fwhm';
 
 /**
  * Calculate the peak height for a given area and fwhm.

--- a/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
+++ b/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
@@ -1,10 +1,6 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 
 export interface GeneralizedLorentzianClassOptions {
   /**
@@ -92,7 +88,7 @@ export class GeneralizedLorentzian implements Shape1DClass {
     return calculateGeneralizedLorentzianHeight({ fwhm, area, gamma });
   }
 
-  public getParameters(): ParameterTuple<['fwhm', 'gamma']> {
+  public getParameters(): GeneralizedLorentzianParameter[] {
     return ['fwhm', 'gamma'];
   }
 
@@ -105,6 +101,9 @@ export class GeneralizedLorentzian implements Shape1DClass {
     return { fct, dx, parameters: [dFwhm, dGamma] };
   }
 }
+
+/** Parameters characterizing a generalized lorentzian shape. */
+export type GeneralizedLorentzianParameter = 'fwhm' | 'gamma';
 
 export const calculateGeneralizedLorentzianHeight = ({
   fwhm = 1,

--- a/src/shapes/1d/lorentzian/Lorentzian.ts
+++ b/src/shapes/1d/lorentzian/Lorentzian.ts
@@ -1,10 +1,6 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 
 export interface LorentzianClassOptions {
   /**
@@ -68,7 +64,7 @@ export class Lorentzian implements Shape1DClass {
     return calculateLorentzianHeight({ fwhm: this.fwhm, area });
   }
 
-  public getParameters(): ParameterTuple<['fwhm']> {
+  public getParameters(): LorentzianParameter[] {
     return ['fwhm'];
   }
 
@@ -77,6 +73,9 @@ export class Lorentzian implements Shape1DClass {
     return { fct, dx, parameters: [dFwhm] };
   }
 }
+
+/** Parameters characterizing a lorentzian shape. */
+export type LorentzianParameter = 'fwhm';
 
 export const calculateLorentzianHeight = ({ fwhm = 1, area = 1 }) => {
   return (2 * area) / Math.PI / fwhm;

--- a/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
+++ b/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
@@ -1,9 +1,5 @@
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import type { LorentzianClassOptions } from '../lorentzian/Lorentzian.ts';
 import {
   calculateLorentzianHeight,
@@ -53,7 +49,7 @@ export class LorentzianDispersive implements Shape1DClass {
     return calculateLorentzianHeight({ fwhm: this.fwhm, area });
   }
 
-  public getParameters(): ParameterTuple<['fwhm']> {
+  public getParameters(): LorentzianDispersiveParameter[] {
     return ['fwhm'];
   }
 
@@ -62,6 +58,9 @@ export class LorentzianDispersive implements Shape1DClass {
     return { fct, dx, parameters: [dFwhm] };
   }
 }
+
+/** Parameters characterizing a dispersive lorentzian shape. */
+export type LorentzianDispersiveParameter = 'fwhm';
 
 export const lorentzianDispersiveFct = (x: number, fwhm: number) => {
   return (2 * fwhm * x) / (4 * x ** 2 + fwhm ** 2);

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -5,11 +5,7 @@ import {
   ROOT_PI_OVER_LN2,
 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import { gaussianFct } from '../gaussian/Gaussian.ts';
 import { lorentzianFct } from '../lorentzian/Lorentzian.ts';
 
@@ -113,7 +109,7 @@ export class PseudoVoigt implements Shape1DClass {
     return calculatePseudoVoigtHeight({ fwhm: this.fwhm, mu: this.mu, area });
   }
 
-  public getParameters(): ParameterTuple<['fwhm', 'mu']> {
+  public getParameters(): PseudoVoigtParameter[] {
     return ['fwhm', 'mu'];
   }
 
@@ -126,6 +122,9 @@ export class PseudoVoigt implements Shape1DClass {
     return { fct, dx, parameters: [dFwhm, dMu] };
   }
 }
+
+/** Parameters characterizing a pseudo-Voigt shape. */
+export type PseudoVoigtParameter = 'fwhm' | 'mu';
 
 export const calculatePseudoVoigtHeight = (
   options: CalculatePseudoVoightHeightOptions = {},

--- a/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
@@ -3,11 +3,7 @@ import {
   GAUSSIAN_EXP_FACTOR,
 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import {
   calculatePseudoVoigtHeight,
   getPseudoVoigtArea,
@@ -169,7 +165,7 @@ export class PseudoVoigtTCH implements Shape1DClass {
     });
   }
 
-  public getParameters(): ParameterTuple<['fwhmG', 'fwhmL']> {
+  public getParameters(): PseudoVoigtTCHParameter[] {
     return ['fwhmG', 'fwhmL'];
   }
 
@@ -182,6 +178,9 @@ export class PseudoVoigtTCH implements Shape1DClass {
     return { fct, dx, parameters: [dFwhmG, dFwhmL] };
   }
 }
+
+/** Parameters characterizing a TCH pseudo-Voigt shape. */
+export type PseudoVoigtTCHParameter = 'fwhmG' | 'fwhmL';
 
 /**
  * Analytical value and partial derivatives of the TCH pseudo-Voigt function centered at x=0.

--- a/src/shapes/1d/splitGaussian/SplitGaussian.ts
+++ b/src/shapes/1d/splitGaussian/SplitGaussian.ts
@@ -1,10 +1,6 @@
 import { ROOT_PI_OVER_LN2 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type {
-  ParameterTuple,
-  Shape1DClass,
-  Shape1DDerivative,
-} from '../Shape1DClass.ts';
+import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import {
   gaussianDerivative,
   gaussianFct,
@@ -144,7 +140,7 @@ export class SplitGaussian implements Shape1DClass {
     });
   }
 
-  public getParameters(): ParameterTuple<['fwhmLow', 'fwhmHigh']> {
+  public getParameters(): SplitGaussianParameter[] {
     return ['fwhmLow', 'fwhmHigh'];
   }
 
@@ -157,6 +153,9 @@ export class SplitGaussian implements Shape1DClass {
     return { fct, dx, parameters: [dFwhmLow, dFwhmHigh] };
   }
 }
+
+/** Parameters characterizing a split gaussian shape. */
+export type SplitGaussianParameter = 'fwhmLow' | 'fwhmHigh';
 
 /**
  * Calculate the peak height for a given area and both half-widths.


### PR DESCRIPTION
The `Parameter` union listed the parameters of every shape in one place, away from the shapes themselves, and `ParameterTuple` existed only to constrain a shape's tuple against that list. Each shape now declares its own `<Shape>Parameter` union next to its class and `Shape1DParameter` combines them.
