### PR TITLE
fix: expose union type of shapes that have a fwhm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,9 @@ export type {
   PseudoVoigtTCHShape1D,
   Shape1D,
   Shape1DKind,
+  Shape1DWithFWHM,
   SplitGaussianShape1D,
-} from './shapes/1d/Shape1D.ts';
+} from './shapes/1d/shape_1d.ts';
 export type {
   GaussianShape2D,
   Shape2D,

--- a/src/shapes/1d/Shape1DClass.ts
+++ b/src/shapes/1d/Shape1DClass.ts
@@ -1,13 +1,13 @@
 import type { DoubleArray } from 'cheminfo-types';
 
 import type { GetData1DOptions } from './GetData1DOptions.ts';
-import type { Shape1D, Shape1DKind } from './Shape1D.ts';
 import type { GaussianParameter } from './gaussian/Gaussian.ts';
 import type { GeneralizedLorentzianParameter } from './generalizedLorentzian/GeneralizedLorentzian.ts';
 import type { LorentzianParameter } from './lorentzian/Lorentzian.ts';
 import type { LorentzianDispersiveParameter } from './lorentzianDispersive/LorentzianDispersive.ts';
 import type { PseudoVoigtParameter } from './pseudoVoigt/PseudoVoigt.ts';
 import type { PseudoVoigtTCHParameter } from './pseudoVoigtTCH/PseudoVoigtTCH.ts';
+import type { Shape1D, Shape1DKind } from './shape_1d.ts';
 import type { SplitGaussianParameter } from './splitGaussian/SplitGaussian.ts';
 
 /**

--- a/src/shapes/1d/__tests__/getShape1D.test.ts
+++ b/src/shapes/1d/__tests__/getShape1D.test.ts
@@ -1,9 +1,9 @@
 import { expect, expectTypeOf, test } from 'vitest';
 
-import type { Shape1D } from '../Shape1D.ts';
 import type { Shape1DInstance } from '../Shape1DInstance.ts';
 import { Gaussian } from '../gaussian/Gaussian.ts';
 import { getShape1D } from '../getShape1D.ts';
+import type { Shape1D } from '../shape_1d.ts';
 import { SplitGaussian } from '../splitGaussian/SplitGaussian.ts';
 
 test('returns a Gaussian instance for gaussian input', () => {

--- a/src/shapes/1d/__tests__/shapeKind.test.ts
+++ b/src/shapes/1d/__tests__/shapeKind.test.ts
@@ -1,9 +1,9 @@
 import { expect, expectTypeOf, test } from 'vitest';
 
-import type { Shape1D } from '../Shape1D.ts';
 import type { Shape1DInstance } from '../Shape1DInstance.ts';
 import { getShape1D } from '../getShape1D.ts';
 import { PseudoVoigtTCH } from '../pseudoVoigtTCH/PseudoVoigtTCH.ts';
+import type { Shape1D } from '../shape_1d.ts';
 
 interface ShapeCase {
   shape: Shape1D;

--- a/src/shapes/1d/__tests__/shape_1d.test-d.ts
+++ b/src/shapes/1d/__tests__/shape_1d.test-d.ts
@@ -1,0 +1,12 @@
+import { expectTypeOf, test } from 'vitest';
+
+import type { Shape1DWithFWHM } from '../shape_1d.ts';
+
+test('Shape1DWithFWHM should only contain types with a `fwhm` property', () => {
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  function test(shape: Shape1DWithFWHM) {
+    // If this test fails, update Shape1DWithFWHM to exclude other shapes that don't have a `fwhm` property.
+    expectTypeOf(shape).toExtend<{ fwhm?: number }>();
+  }
+  test({ kind: 'gaussian' });
+});

--- a/src/shapes/1d/gaussian/Gaussian.ts
+++ b/src/shapes/1d/gaussian/Gaussian.ts
@@ -6,8 +6,8 @@ import {
 } from '../../../util/constants.ts';
 import erfinv from '../../../util/erfinv.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { GaussianShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
+import type { GaussianShape1D } from '../shape_1d.ts';
 
 interface CalculateGaussianHeightOptions {
   /**

--- a/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
+++ b/src/shapes/1d/generalizedLorentzian/GeneralizedLorentzian.ts
@@ -1,7 +1,7 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { GeneralizedLorentzianShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
+import type { GeneralizedLorentzianShape1D } from '../shape_1d.ts';
 
 export interface GeneralizedLorentzianClassOptions {
   /**

--- a/src/shapes/1d/getShape1D.ts
+++ b/src/shapes/1d/getShape1D.ts
@@ -1,4 +1,3 @@
-import type { Shape1D } from './Shape1D.ts';
 import type { Shape1DInstance } from './Shape1DInstance.ts';
 import { Gaussian } from './gaussian/Gaussian.ts';
 import { GeneralizedLorentzian } from './generalizedLorentzian/GeneralizedLorentzian.ts';
@@ -6,6 +5,7 @@ import { Lorentzian } from './lorentzian/Lorentzian.ts';
 import { LorentzianDispersive } from './lorentzianDispersive/LorentzianDispersive.ts';
 import { PseudoVoigt } from './pseudoVoigt/PseudoVoigt.ts';
 import { PseudoVoigtTCH } from './pseudoVoigtTCH/PseudoVoigtTCH.ts';
+import type { Shape1D } from './shape_1d.ts';
 import { SplitGaussian } from './splitGaussian/SplitGaussian.ts';
 
 /**

--- a/src/shapes/1d/lorentzian/Lorentzian.ts
+++ b/src/shapes/1d/lorentzian/Lorentzian.ts
@@ -1,7 +1,7 @@
 import { ROOT_THREE } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { LorentzianShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
+import type { LorentzianShape1D } from '../shape_1d.ts';
 
 export interface LorentzianClassOptions {
   /**

--- a/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
+++ b/src/shapes/1d/lorentzianDispersive/LorentzianDispersive.ts
@@ -1,5 +1,4 @@
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { LorentzianDispersiveShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import type { LorentzianClassOptions } from '../lorentzian/Lorentzian.ts';
 import {
@@ -8,6 +7,7 @@ import {
   lorentzianFwhmToWidth,
   lorentzianWidthToFWHM,
 } from '../lorentzian/Lorentzian.ts';
+import type { LorentzianDispersiveShape1D } from '../shape_1d.ts';
 
 export class LorentzianDispersive implements Shape1DClass {
   public readonly kind = 'lorentzianDispersive' as const;

--- a/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
+++ b/src/shapes/1d/pseudoVoigt/PseudoVoigt.ts
@@ -5,10 +5,10 @@ import {
   ROOT_PI_OVER_LN2,
 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { PseudoVoigtShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import { gaussianFct } from '../gaussian/Gaussian.ts';
 import { lorentzianFct } from '../lorentzian/Lorentzian.ts';
+import type { PseudoVoigtShape1D } from '../shape_1d.ts';
 
 import { pseudoVoigtFindFactor } from './computeFactor.ts';
 

--- a/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
+++ b/src/shapes/1d/pseudoVoigtTCH/PseudoVoigtTCH.ts
@@ -3,7 +3,6 @@ import {
   GAUSSIAN_EXP_FACTOR,
 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { PseudoVoigtTCHShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import {
   calculatePseudoVoigtHeight,
@@ -14,6 +13,7 @@ import {
   pseudoVoigtFwhmToWidth,
   pseudoVoigtWidthToFWHM,
 } from '../pseudoVoigt/PseudoVoigt.ts';
+import type { PseudoVoigtTCHShape1D } from '../shape_1d.ts';
 
 export interface PseudoVoigtTCHClassOptions {
   /**

--- a/src/shapes/1d/shape_1d.ts
+++ b/src/shapes/1d/shape_1d.ts
@@ -39,6 +39,9 @@ export interface SplitGaussianShape1D extends SplitGaussianClassOptions {
 /** Discriminant of every 1D shape. */
 export type Shape1DKind = Shape1D['kind'];
 
+/**
+ * All supported 1D shapes.
+ */
 export type Shape1D =
   | GaussianShape1D
   | LorentzianShape1D
@@ -47,3 +50,8 @@ export type Shape1D =
   | GeneralizedLorentzianShape1D
   | PseudoVoigtTCHShape1D
   | SplitGaussianShape1D;
+
+/**
+ * All supported 1D shapes that have a FWHM parameter.
+ */
+export type Shape1DWithFWHM = Exclude<Shape1D, { kind: 'splitGaussian' }>;

--- a/src/shapes/1d/splitGaussian/SplitGaussian.ts
+++ b/src/shapes/1d/splitGaussian/SplitGaussian.ts
@@ -1,6 +1,5 @@
 import { ROOT_PI_OVER_LN2 } from '../../../util/constants.ts';
 import type { GetData1DOptions } from '../GetData1DOptions.ts';
-import type { SplitGaussianShape1D } from '../Shape1D.ts';
 import type { Shape1DClass, Shape1DDerivative } from '../Shape1DClass.ts';
 import {
   gaussianDerivative,
@@ -9,6 +8,7 @@ import {
   gaussianWidthToFWHM,
   getGaussianFactor,
 } from '../gaussian/Gaussian.ts';
+import type { SplitGaussianShape1D } from '../shape_1d.ts';
 
 export interface SplitGaussianClassOptions {
   /**


### PR DESCRIPTION
There are packages such as `ml-gsd` that depend on the existence of this field on all treated shapes.
